### PR TITLE
GitHub Pages required updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,11 +24,6 @@ defaults:
     values:
       author: "Aaron S. West"
 
-# Build settings
-markdown: redcarpet
-redcarpet:
-  extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "strikethrough", "superscript"]
-
 # Includes an icon in the footer for each username you enter
 # ASW: Jul 18, 2015, 7:13 PM
 # Footer links aren't being used as this code came from Jekyll Now. One day perhaps.
@@ -53,20 +48,6 @@ disqus: aaronsengineeringnotebook
 
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
 google_analytics: UA-3548918-9
-
-#
-# !! You don't need to change any of the configuration flags below !!
-#
-#markdown: redcarpet
-highlighter: pygments
-#permalink: /:title/
-
-# The release of Jekyll Now that you're using
-# version: v1.1.0
-
-# Set the Sass partials directory, as we're using @imports
-#sass:
-#  style: :expanded # You might prefer to minify using :compressed
 
 # Use the following plug-ins
 gems:

--- a/_posts/2015-07-19-generating-ssh-keys.md
+++ b/_posts/2015-07-19-generating-ssh-keys.md
@@ -6,18 +6,18 @@ tags: [cli, os x]
 ---
 Generating an SSH key without a password. For example, for passphraseless old school Hadoop clusters. This is generally done from within a users home directory such as /Users/username on Mac.
 
-```bash
+~~~bash
 ssh-keygen -t rsa -P ""
-```
+~~~
 
 Generating an SSH key with a password. This is generally done from within a users home directory such as /User/username on Mac.
 
-```bash
+~~~bash
 ssh-keygen -t rsa
-```
+~~~
 
 How to copy a generated SSH key to the Mac clipboard. This is arguably better than manually copying and pasting.
 
-```bash
+~~~bash
 cat ~/.ssh/id_rsa.pub | pbcopy
-```
+~~~

--- a/_posts/2015-07-20-flushing-dns-mac.md
+++ b/_posts/2015-07-20-flushing-dns-mac.md
@@ -9,38 +9,38 @@ Below are the various Bash commands needed to flush DNS on Mac OS X. There are s
 #### Flush DNS on OS X Yosemite 10.10.4 and Newer
 When 10.11.x aka 'El Capitan' ships this command should continue to function. This set of commands will flush all DNS caches on OS X including Multicast DNS and Unicast DNS.
 
-```bash
+~~~bash
 sudo dscacheutil -flushcache; sudo killall -HUP mDNSResponder
-```
+~~~
 
 #### Flush DNS on OS X Yosemite 10.10 through 10.10.3
 In these versions of OS X there are two separate commands to execute to clear the two difference DNS caches, Multicast DNS and Unicast DNS. You can run only one of these commands if you know which cache you are targeting or both if you prefer a more heavy-handed approach.
 
-```bash
+~~~bash
 # Option 1: Clear Multicast DNS
 sudo discoveryutil mdnsflushcache
 # Option 2: Clear Unicast DNS
 sudo discoveryutil udnsflushcaches
 # Option 3: Concatenate both commands.
 sudo discoveryutil mdnsflushcache; sudo discoveryutil udnsflushcaches
-```
+~~~
 
 #### Flush DNS on OS X Mavericks 10.9
-```bash
+~~~bash
 dscacheutil -flushcache; sudo killall -HUP mDNSResponder
-```
+~~~
 
 #### Flush DNS on OS X Lion 10.7 and OS X Mountain Lion 10.8
-```bash
+~~~bash
 sudo killall -HUP mDNSResponder
-```
+~~~
 
 #### Flush DNS on OS X Leopard 10.5 and OS X Snow Leopard 10.6
-```bash
+~~~bash
 sudo dscacheutil -flushcache
-```
+~~~
 
 #### Flush DNS on OS X Tiger 10.4 and Earlier
-```bash
+~~~bash
 lookupd -flushcache
-```
+~~~

--- a/_posts/2015-07-23-retrieve-wifi-password-mac.md
+++ b/_posts/2015-07-23-retrieve-wifi-password-mac.md
@@ -8,8 +8,8 @@ I don't generally forget the password for Wi-Fi networks I use, mainly because I
 
 In the command below I read the the keychain and hone in on just the password portion. Replace `<SSID_NAME>` with the name of of a valid SSID you've connected with in the past. Keep in mind case sensitivity matters. You can leave off `| grep password` and retrieve the whole item too. This command requires authentication so you'll be asked to enter your username and password.
 
-```bash
+~~~bash
 security find-generic-password -ga <SSID_NAME> | grep password
-```
+~~~
 
 There's lots more the `security` program can do. Read the man pages and you'll see a list of available commands such as: `create-keypair`, `add-generic-password`, `list-keychains`.

--- a/_posts/2015-07-26-backgrounding-linux-processes.md
+++ b/_posts/2015-07-26-backgrounding-linux-processes.md
@@ -6,9 +6,9 @@ tags: [cli, linux]
 ---
 This week our data team were talking about ways to run a Python script without having the execution attached to your console session. There's more than way one to accomplish this but here's the one they settled on.
 
-```bash
+~~~bash
 nohup python python_script.py </dev/null &
-```
+~~~
 
 The discussion reminded me of a similar, and equally useful, workflow we had a Dataium. We used all kinds of databases over the years but in the beginning MySQL 5.5.x was our goto. We operated a fairly sizable database which served as a backend to a desktop Adobe AIR / Flex application. One of the challenges we had with the configuration was performance following a database restart. We approached this problem by writing SQL scripts which mirrored common query patterns from our users. This concept of *warming the MySQL query cache* was incredibly useful.
 
@@ -18,23 +18,23 @@ We got around this issue by _backgrounding_ the Bash scripts after we started th
 
 With a Bash script running in the terminal we forced it to the background using the following.
 
-```bash
+~~~bash
 # Execute a bash script. After it is running press CTRL + z.
 CTRL + z
 # Next, press bg to background the process.
 bg
-```
+~~~
 
 Now, you can use your terminal session for other things. To see which processes have been backgrounded you can run this command:
 
-```bash
+~~~bash
 jobs
-```
+~~~
 
 Even though the script is running in the background it is still associated with the logged in terminal user. If you need to change this for some reason, lets imagine it's the end of day and you're heading home, you can view the list of running `jobs` to get the job ID from the list. Then, you can use the `disown` command to disown the process/job. This tells Linux not to send a SIGHUP to the job if your shell receives a SIGHUP.
 
-```bash
+~~~bash
 jobs
 (get the job ID from the console output)
 disown -h %1
-```
+~~~

--- a/_posts/2015-07-30-exporting-importing-github-labels.md
+++ b/_posts/2015-07-30-exporting-importing-github-labels.md
@@ -14,7 +14,7 @@ I found a solution but it wasn't something offered by GitHub natively.
 
 The first step is to export the labels in an existing repo. I found some [JavaScript code](https://gist.github.com/MoOx/93c2853fee760f42d97f) that did this. The code is also below. To use it I navigated to a repo with the labels already configured like I wanted. Then I opened the JS console, pasted the code below, and ran it. This created a JSON data set in the console which I copied into a new file called `github-labels.json` on my Mac.
 
-```javascript
+~~~javascript
 var labels = [];
 [].slice.call(document.querySelectorAll(".label-link"))
 .forEach(function(element) {
@@ -32,7 +32,7 @@ var labels = [];
   })
 })
 console.log(JSON.stringify(labels, null, 2))
-```
+~~~
 
 ## Install `github-labels` package via NPM
 
@@ -40,9 +40,9 @@ Next, I used a tool called [`git-labels`](https://github.com/popomore/github-lab
 
 Install `git-labels` as a global NPM module.
 
-```bash
+~~~bash
 npm install -g github-labels
-```
+~~~
 
 With `git-labels` installed there are two choices for importing labels into an existing repo. You can read from the saved JSON file and append to an existing label set or you can overwrite all the labels in the repo. For my use case, the overwrite method provided exactly what I needed.
 
@@ -50,12 +50,12 @@ Change the path and filename to your JSON file, `user` with your GitHub username
 
 _Add labels from JSON to existing GitHub labels (no overwrite)_
 
-```bash
+~~~bash
 labels -c /path/to/github-labels.json user/repo
-```
+~~~
 
 _Overwrite all existing GitHub labels with labels from JSON file_
 
-```bash
+~~~bash
 labels -c /path/to/github-labels.json -f user/repo
-```
+~~~

--- a/_posts/2015-08-03-better-documentation-using-conventional-changelog.md
+++ b/_posts/2015-08-03-better-documentation-using-conventional-changelog.md
@@ -52,7 +52,7 @@ There are likely several ways you can go about incorporating `conventional-chang
 
 More detail is provided in the `conventional-changelog` README, but here's the basics of installing and using `conventional-changelog`.
 
-```bash
+~~~bash
 # Install the tool using npm. Since it's a CLI tool you must install with -g
 npm install -g conventional-changelog
 
@@ -60,4 +60,4 @@ npm install -g conventional-changelog
 
 # Generate CHANGELOG.md using the AngularJS convention
 conventional-changelog -o CHANGELOG.md -p angular -v
-```
+~~~


### PR DESCRIPTION
- changes to `_config.yml`
- convert all backtick code blocks to use tildes due to [this bug in Jekyll 3](https://github.com/jekyll/jekyll/issues/4427)
